### PR TITLE
fixed spelling error in `polygon.js`

### DIFF
--- a/blocks_common/polygon.js
+++ b/blocks_common/polygon.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-goog.provide('Blockly.Blocks.ploygon');
+goog.provide('Blockly.Blocks.polygon');
 goog.require('Blockly.Blocks');
 goog.require('Blockly.Colours');
 goog.require('Blockly.constants');


### PR DESCRIPTION
### Proposed Changes

This is literally just a pull request to fix a spelling mistake in `blocks_common/polygon.js`.

### Reason for Changes

This change should be made to avoid confusion, but to be honest I made this pull request to show my interest in joining the @PenguinMod org.