### PR TITLE
Add currently playing sounds

### DIFF
--- a/blocks_vertical/sound.js
+++ b/blocks_vertical/sound.js
@@ -492,3 +492,19 @@ Blockly.Blocks['sound_getSoundVolume'] = {
     });
   }
 };
+
+Blockly.Blocks['sound_currentlyPlayingSounds'] = {
+  /**
+   * pm: Block to report the volume of a sound at the current position.
+   * @this Blockly.Block
+   */
+  init: function () {
+    this.jsonInit({
+      "message0": "currently playing sounds",
+      "args0": [],
+      "category": Blockly.Categories.sound,
+      "checkboxInFlyout": true,
+      "extensions": ["colours_sounds", "output_string"]
+    });
+  }
+};


### PR DESCRIPTION
Resolves https://github.com/PenguinMod/PenguinMod-Home/issues/471

The adds a new block to the sound category which lists out all sounds which are currently playing. Primary point of this PR is that this block looked really easy to implement, so I implemented it.

## Related

* https://github.com/PenguinMod/PenguinMod-Vm/pull/171
* https://github.com/PenguinMod/penguinmod.github.io/pull/186