### PR TITLE
Allow custom block shapes to have a base internal/external padding

### DIFF
--- a/core/block_render.js
+++ b/core/block_render.js
@@ -490,6 +490,9 @@ Blockly.BlockSvg.FIELD_TEXTINPUT_ANIMATE_POSITIONING = false;
  * See also: `Blockly.BlockSvg.computeOutputPadding_`.
  */
 Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING = {
+  base : { // Outer shape: any.
+    
+  },
   1 : { // Outer shape: hexagon.
     0 : 5 * Blockly.BlockSvg.GRID_UNIT, // Field in hexagon.
     1 : 2 * Blockly.BlockSvg.GRID_UNIT, // Hexagon in hexagon.

--- a/core/block_render.js
+++ b/core/block_render.js
@@ -491,7 +491,6 @@ Blockly.BlockSvg.FIELD_TEXTINPUT_ANIMATE_POSITIONING = false;
  */
 Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING = {
   base : { // Outer shape: any.
-    
   },
   1 : { // Outer shape: hexagon.
     0 : 5 * Blockly.BlockSvg.GRID_UNIT, // Field in hexagon.
@@ -1319,8 +1318,11 @@ Blockly.BlockSvg.prototype.computeOutputPadding_ = function(inputRows) {
     row.paddingStart += customShape.blockPaddingStart(this, otherShape, firstInput, firstField, row);
   }
 
-  const paddingStart = (Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING[shape] || {})[otherShape];
-  row.paddingStart += paddingStart === undefined ? Blockly.BlockSvg.DEFAULT_SHAPE_PADDING : paddingStart;
+  const internalPadding = (Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING[shape] || {});
+  const paddingStart = internalPadding[otherShape] ?? Blockly.BlockSvg.DEFAULT_SHAPE_PADDING
+    + internalPadding.base ?? 0
+    + Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING.base[otherShape] ?? 0;
+  row.paddingStart += paddingStart;
 
   // End row padding: based on last input or last field.
   var lastInput = row[row.length - 1];
@@ -1356,8 +1358,10 @@ Blockly.BlockSvg.prototype.computeOutputPadding_ = function(inputRows) {
     row.paddingEnd += customShape.blockPaddingEnd(this, otherShape, lastInput, lastField, row);
   }
 
-  const paddingEnd = (Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING[shape] || {})[otherShape];
-  row.paddingEnd += paddingEnd === undefined ? Blockly.BlockSvg.DEFAULT_SHAPE_PADDING : paddingEnd;
+  const paddingEnd = internalPadding[otherShape] ?? Blockly.BlockSvg.DEFAULT_SHAPE_PADDING
+    + internalPadding.base ?? 0
+    + Blockly.BlockSvg.SHAPE_IN_SHAPE_PADDING.base[otherShape] ?? 0;
+  row.paddingEnd += paddingEnd;
 };
 
 /**


### PR DESCRIPTION
### Resolves

There is no easy way for a custom block shape to specify an internal/external padding that should apply for _all_ other shapes.

### Proposed Changes

Allows the `base` key to be used in `blockPadding.internal` or `blockPadding.external` of custom block shapes. This will add a "base" padding that will apply to all other shapes, and will be combined with any specific paddings.

### Reason for Changes

This makes it easier to create proper padding for custom block shapes and improves base compatibility between extensions.
